### PR TITLE
Update build_action.sh

### DIFF
--- a/build_action.sh
+++ b/build_action.sh
@@ -34,5 +34,6 @@ make deb-pkg -j"$CPU_CORES"
 
 # move deb packages to artifact dir
 cd ..
+rm -rfv *dbg*.deb
 mkdir "artifact"
 mv ./*.deb artifact/


### PR DESCRIPTION
禁用dbg命令失效时，自动删除dbg，以节省下载时间